### PR TITLE
Add TLS support for Vault

### DIFF
--- a/bootstrap_vbox.sh
+++ b/bootstrap_vbox.sh
@@ -1,64 +1,106 @@
 #!/bin/bash
 set -e
+INITIAL=False
+TLS=False
 
+if [[ $* == *--initial* ]]; then
+    INITIAL=True
+fi
+
+if [[ $* == *--tls* ]]; then
+    TLS=True
+fi
+
+SCRIPTPATH=$(dirname $(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd -P)/$(basename "${BASH_SOURCE[0]}"))
+WORKSPACE=$(dirname ${SCRIPTPATH})
+PARRENTPATH=$(dirname ${WORKSPACE})
+DEPLOYMENTS=${PARRENTPATH}/deployments/vbox
+
+STEMCELLNAME=bosh-warden-boshlite-ubuntu-xenial-go_agent
+STEMCELLVERSION=315.64
+STEMCELLSHA1=bfeacdd2ef178742b211c9ea7f154e58fb28639a
 ## Prepare environment
-[ ! -d ~/deployments ] && mkdir -p ~/deployments
-[ ! -d ~/deployments/vbox ] && mkdir -p ~/deployments/vbox
+[ ! -d ${DEPLOYMENTS} ] && mkdir -p ${DEPLOYMENTS}
 
-pushd ~/workspace
-[ ! -d ~/workspace/bosh-deployment ] && git clone https://github.com/cloudfoundry/bosh-deployment.git
-[ ! -d ~/workspace/safe-boshrelease ] && git clone https://github.com/cloudfoundry-community/safe-boshrelease.git
-[ ! -d ~/workspace/concourse-bosh-deployment ] && git clone https://github.com/concourse/concourse-bosh-deployment.git
-[ ! -d ~/workspace/minio-boshrelease ] && git clone https://github.com/minio/minio-boshrelease.git
+pushd ${WORKSPACE}
+[ ! -d ${WORKSPACE}/bosh-deployment ] && git clone https://github.com/cloudfoundry/bosh-deployment.git
+[ ! -d ${WORKSPACE}/safe-boshrelease ] && git clone https://github.com/cloudfoundry-community/safe-boshrelease.git
+[ ! -d ${WORKSPACE}/concourse-bosh-deployment ] && git clone https://github.com/concourse/concourse-bosh-deployment.git
+[ ! -d ${WORKSPACE}/minio-boshrelease ] && git clone https://github.com/minio/minio-boshrelease.git
 popd
 
 ## Deploy Director
-bosh create-env ~/workspace/bosh-deployment/bosh.yml \
+bosh create-env ${WORKSPACE}/bosh-deployment/bosh.yml \
   --non-interactive \
-  --state ~/deployments/vbox/state.json \
-  -o ~/workspace/bosh-deployment/virtualbox/cpi.yml \
-  -o ~/workspace/bosh-deployment/virtualbox/outbound-network.yml \
-  -o ~/workspace/bosh-deployment/bosh-lite.yml \
-  -o ~/workspace/bosh-deployment/bosh-lite-runc.yml \
-  -o ~/workspace/bosh-deployment/uaa.yml \
-  -o ~/workspace/bosh-deployment/credhub.yml \
-  -o ~/workspace/bosh-deployment/jumpbox-user.yml \
-  -o ~/workspace/bootstrap-vbox/bosh/patch/manifest-patch.yml \
-  --vars-store ~/deployments/vbox/bosh-creds.yml \
-  --vars-file ~/workspace/bootstrap-vbox/bosh/params/bosh-params.yml
+  --state ${DEPLOYMENTS}/state.json \
+  -o ${WORKSPACE}/bosh-deployment/virtualbox/cpi.yml \
+  -o ${WORKSPACE}/bosh-deployment/virtualbox/outbound-network.yml \
+  -o ${WORKSPACE}/bosh-deployment/bosh-lite.yml \
+  -o ${WORKSPACE}/bosh-deployment/bosh-lite-runc.yml \
+  -o ${WORKSPACE}/bosh-deployment/uaa.yml \
+  -o ${WORKSPACE}/bosh-deployment/credhub.yml \
+  -o ${WORKSPACE}/bosh-deployment/jumpbox-user.yml \
+  -o ${WORKSPACE}/bootstrap-vbox/bosh/patch/manifest-patch.yml \
+  --vars-store ${DEPLOYMENTS}/bosh-creds.yml \
+  --vars-file ${WORKSPACE}/bootstrap-vbox/bosh/params/bosh-params.yml
 
 export BOSH_DEPLOYMENT=vbox
 export BOSH_ENVIRONMENT=https://192.168.50.6:25555
-export BOSH_CA_CERT="$(bosh int ~/deployments/vbox/bosh-creds.yml --path /director_ssl/ca)"
+export BOSH_CA_CERT="$(bosh int ${DEPLOYMENTS}/bosh-creds.yml --path /director_ssl/ca)"
 export BOSH_CLIENT=admin
-export BOSH_CLIENT_SECRET=`bosh int ~/deployments/vbox/bosh-creds.yml --path /admin_password`
+export BOSH_CLIENT_SECRET=`bosh int ${DEPLOYMENTS}/bosh-creds.yml --path /admin_password`
 
 ## Prepare bosh for Vault, Concourse, and Minio Deployments
-bosh upload-stemcell --sha1 bfeacdd2ef178742b211c9ea7f154e58fb28639a \
-  https://bosh.io/d/stemcells/bosh-warden-boshlite-ubuntu-xenial-go_agent?v=315.64
+FOUNDSTEMCELLNAME=$(bosh stemcells --column Name | tr -d ' ')
+FOUNDSTEMCELLVERSION=$(bosh stemcells --column Version | tr -d ' ' | grep -oe [0-9.]*)
+if [[ "${FOUNDSTEMCELLNAME}" -eq "${STEMCELLNAME}" ]]; then
+    if [[ "${FOUNDSTEMCELLVERSION}" == "${STEMCELLVERSION}" ]]; then
+        echo "Stemcell '${STEMCELLNAME} ${STEMCELLVERSION}' already exists."
+    else
+        echo "Stemcell Version --- '${FOUNDSTEMCELLNAME} ${FOUNDSTEMCELLVERSION}'"
+        bosh upload-stemcell --sha1 ${STEMCELLSHA1} \
+            https://bosh.io/d/stemcells/${STEMCELLNAME}?v=${STEMCELLVERSION}
+    fi
+else
+    echo "Stemcell Name --- '$(echo ${STEMCELLNAME} | sha1sum)'"
+    echo "Found Stemcell Name --- '$(echo ${FOUNDSTEMCELLNAME} | sha1sum)'"
+    bosh upload-stemcell --sha1 ${STEMCELLSHA1} \
+        https://bosh.io/d/stemcells/${STEMCELLNAME}?v=${STEMCELLVERSION}
+fi
 
-bosh update-cloud-config ~/workspace/bootstrap-vbox/cloud-config/vbox-cloud-config.yml \
+bosh update-cloud-config ${WORKSPACE}/bootstrap-vbox/cloud-config/vbox-cloud-config.yml \
   --non-interactive \
 
+if [[ "${TLS}" == 'True' ]]; then
+    echo "Patch TLS"
+    ## Patch Vault manifest yaml
+    VAULTMANIFEST=${WORKSPACE}/bootstrap-vbox/vault/safe.yml
+    awk '/safe:/{print;print "            tls:\n              certificate:\n              key:";next}1' ${WORKSPACE}/safe-boshrelease/manifests/safe.yml > ${VAULTMANIFEST}
+    VAULTPATCH=${WORKSPACE}/bootstrap-vbox/vault/patch/manifest-patch-tls.yml
+else
+    echo "NO Patch TLS"
+    VAULTMANIFEST=${WORKSPACE}/safe-boshrelease/manifests/safe.yml
+    VAULTPATCH=${WORKSPACE}/bootstrap-vbox/vault/patch/manifest-patch.yml
+fi
 ## Deploy Vault
-bosh  deploy -d vault ~/workspace/safe-boshrelease/manifests/safe.yml \
+bosh  deploy -d vault ${VAULTMANIFEST} \
   --non-interactive \
-  -o ~/workspace/bootstrap-vbox/vault/patch/manifest-patch.yml \
-  --vars-store ~/deployments/vbox/vault-creds.yml \
-  --vars-file ~/workspace/bootstrap-vbox/vault/params/vault-params.yml
+  -o ${VAULTPATCH} \
+  --vars-store ${DEPLOYMENTS}/vault-creds.yml \
+  --vars-file ${WORKSPACE}/bootstrap-vbox/vault/params/vault-params.yml
 
 export VAULT_ADDR=https://10.244.16.2
 export VAULT_SKIP_VERIFY=true
 
 # Initialize Vault
-if [[ $* == *--initial* ]]
+if [[ "${INITIAL}" == 'True' ]]
 then
-  vault operator init -format="json" > ~/deployments/vbox/tokens.json
+  vault operator init -format="json" > ${DEPLOYMENTS}/tokens.json
 
-  token0=$(cat ~/deployments/vbox/tokens.json | jq '.unseal_keys_b64[0]')
-  token1=$(cat ~/deployments/vbox/tokens.json | jq '.unseal_keys_b64[1]')
-  token2=$(cat ~/deployments/vbox/tokens.json | jq '.unseal_keys_b64[2]')
-  root_token=$(cat ~/deployments/vbox/tokens.json | jq -r '.root_token')
+  token0=$(cat ${DEPLOYMENTS}/tokens.json | jq '.unseal_keys_b64[0]')
+  token1=$(cat ${DEPLOYMENTS}/tokens.json | jq '.unseal_keys_b64[1]')
+  token2=$(cat ${DEPLOYMENTS}/tokens.json | jq '.unseal_keys_b64[2]')
+  root_token=$(cat ${DEPLOYMENTS}/tokens.json | jq -r '.root_token')
 
   # Unseal the vault
   curl \
@@ -81,43 +123,44 @@ then
   echo "Enabling concourse secrets engine"
   vault secrets enable -version=1 -path=concourse kv
   echo "Creating policy"
-  vault policy write concourse ~/workspace/bootstrap-vbox/vault/policies/concourse-policy.hcl
+  vault policy write concourse ${WORKSPACE}/bootstrap-vbox/vault/policies/concourse-policy.hcl
   echo "Creating token for concourse"
-  vault token create --policy concourse --period 24h > ~/deployments/vbox/concourse-token.json
+  vault token create --policy concourse --period 24h > ${DEPLOYMENTS}/concourse-token.json
 fi
 
 ## Get token from tokens.json file to update concourse params before deploying
 ## TODO: Fix this ugly janky code
-if [[ ! $(cat ~/workspace/bootstrap-vbox/concourse/params/concourse-params.yml | grep concourse_vault_token:) ]]; then
-  concourse_token=$(cat ~/deployments/vbox/concourse-token.json | grep 'token ' | awk '{print $NF}')
-  echo -e "\nconcourse_vault_token: ${concourse_token}" >> ~/workspace/bootstrap-vbox/concourse/params/concourse-params.yml
+if [[ ! $(cat ${WORKSPACE}/bootstrap-vbox/concourse/params/concourse-params.yml | grep concourse_vault_token:) ]]; then
+  concourse_token=$(cat ${DEPLOYMENTS}/concourse-token.json | grep 'token ' | awk '{print $NF}')
+  echo -e "\nconcourse_vault_token: ${concourse_token}" >> ${WORKSPACE}/bootstrap-vbox/concourse/params/concourse-params.yml
 fi
 
 ## Deploy concourse
-bosh deploy -d concourse ~/workspace/concourse-bosh-deployment/cluster/concourse.yml \
+bosh deploy -d concourse ${WORKSPACE}/concourse-bosh-deployment/cluster/concourse.yml \
   --non-interactive \
-  -l ~/workspace/concourse-bosh-deployment/versions.yml \
-  -o ~/workspace/concourse-bosh-deployment/cluster/operations/static-web.yml \
-  -o ~/workspace/concourse-bosh-deployment/cluster/operations/basic-auth.yml \
-  -o ~/workspace/concourse-bosh-deployment/cluster/operations/vault.yml \
-  -o ~/workspace/concourse-bosh-deployment/cluster/operations/vault-shared-path.yml \
-  -o ~/workspace/concourse-bosh-deployment/cluster/operations/vault-tls-skip_verify.yml \
-  -o ~/workspace/bootstrap-vbox/concourse/patch/manifest-patch.yml \
-  --vars-store ~/deployments/vbox/concourse-creds.yml \
-  --vars-file ~/workspace/bootstrap-vbox/concourse/params/concourse-params.yml
+  -l ${WORKSPACE}/concourse-bosh-deployment/versions.yml \
+  -o ${WORKSPACE}/concourse-bosh-deployment/cluster/operations/static-web.yml \
+  -o ${WORKSPACE}/concourse-bosh-deployment/cluster/operations/basic-auth.yml \
+  -o ${WORKSPACE}/concourse-bosh-deployment/cluster/operations/vault.yml \
+  -o ${WORKSPACE}/concourse-bosh-deployment/cluster/operations/vault-shared-path.yml \
+  -o ${WORKSPACE}/concourse-bosh-deployment/cluster/operations/vault-tls-skip_verify.yml \
+  -o ${WORKSPACE}/bootstrap-vbox/concourse/patch/manifest-patch.yml \
+  --vars-store ${DEPLOYMENTS}/concourse-creds.yml \
+  --vars-file ${WORKSPACE}/bootstrap-vbox/concourse/params/concourse-params.yml
 
 ## Deploy Minio
-bosh deploy -d minio ~/workspace/minio-boshrelease/manifests/manifest-fs-example.yml \
+bosh deploy -d minio ${WORKSPACE}/minio-boshrelease/manifests/manifest-fs-example.yml \
   --non-interactive \
-  -o ~/workspace/bootstrap-vbox/minio/patch/manifest-patch.yml \
-  --vars-store ~/deployments/vbox/minio-creds.yml \
-  --vars-file ~/workspace/bootstrap-vbox/minio/params/minio-params.yml
+  -o ${WORKSPACE}/bootstrap-vbox/minio/patch/manifest-patch.yml \
+  --vars-store ${DEPLOYMENTS}/minio-creds.yml \
+  --vars-file ${WORKSPACE}/bootstrap-vbox/minio/params/minio-params.yml
 
 echo "##############################################################################################################################"
 echo "#                              Successfully deployed BOSH, Vault, Concourse, and Minio!                                      #"
 echo "##############################################################################################################################"
+echo "# Add the route to be able to communicate with Bosh & SSH                                                                    #"
 echo "# Alias your environment                                                                                                     #"
-echo "# - cmd: bosh alias-env vbox -e 192.168.50.6 --ca-cert <(bosh int ~/deployments/vbox/bosh-creds.yml --path /director_ssl/ca) #"
+echo "# - cmd: bosh alias-env vbox -e 192.168.50.6 --ca-cert <(bosh int ${DEPLOYMENTS}/bosh-creds.yml --path /director_ssl/ca)     #"
 echo "# - Vault     https://10.244.16.2                                                                                            #"
 echo "# - Concourse http://10.244.16.3:8080                                                                                        #"
 echo "# - Minio     http://10.244.16.4:9000                                                                                        #"

--- a/bootstrap_vbox.sh
+++ b/bootstrap_vbox.sh
@@ -19,6 +19,7 @@ DEPLOYMENTS=${PARRENTPATH}/deployments/vbox
 STEMCELLNAME=bosh-warden-boshlite-ubuntu-xenial-go_agent
 STEMCELLVERSION=315.64
 STEMCELLSHA1=bfeacdd2ef178742b211c9ea7f154e58fb28639a
+
 ## Prepare environment
 [ ! -d ${DEPLOYMENTS} ] && mkdir -p ${DEPLOYMENTS}
 
@@ -57,13 +58,10 @@ if [[ "${FOUNDSTEMCELLNAME}" -eq "${STEMCELLNAME}" ]]; then
     if [[ "${FOUNDSTEMCELLVERSION}" == "${STEMCELLVERSION}" ]]; then
         echo "Stemcell '${STEMCELLNAME} ${STEMCELLVERSION}' already exists."
     else
-        echo "Stemcell Version --- '${FOUNDSTEMCELLNAME} ${FOUNDSTEMCELLVERSION}'"
         bosh upload-stemcell --sha1 ${STEMCELLSHA1} \
             https://bosh.io/d/stemcells/${STEMCELLNAME}?v=${STEMCELLVERSION}
     fi
 else
-    echo "Stemcell Name --- '$(echo ${STEMCELLNAME} | sha1sum)'"
-    echo "Found Stemcell Name --- '$(echo ${FOUNDSTEMCELLNAME} | sha1sum)'"
     bosh upload-stemcell --sha1 ${STEMCELLSHA1} \
         https://bosh.io/d/stemcells/${STEMCELLNAME}?v=${STEMCELLVERSION}
 fi

--- a/vault/patch/manifest-patch-tls.yml
+++ b/vault/patch/manifest-patch-tls.yml
@@ -1,0 +1,53 @@
+---
+- type: replace
+  path: /name
+  value:
+    vault
+
+- type: replace
+  path: /instance_groups/name=vault/azs
+  value:
+    [z1]
+
+- type: replace
+  path: /instance_groups/name=vault/vm_type
+  value:
+    vault-vm
+
+- type: replace
+  path: /instance_groups/name=vault/instances
+  value:
+    1
+
+- type: replace
+  path: /instance_groups/name=vault/persistent_disk_type?
+  value:
+    vault-disk
+
+- type: replace
+  path: /instance_groups/name=vault/jobs/name=vault/properties/safe/config?
+  value:
+    |
+     storage "s3" {
+       access_key = ((s3_access_key))
+       secret_key = ((s3_secret_key))
+       bucket     = ((s3_vault_bucket))
+       endpoint   = ((s3_endpoint))
+       region     = ((s3_region))
+     }
+
+- type: replace
+  path: /instance_groups/name=vault/jobs/name=vault/properties/safe/tls/certificate?
+  value: ((vault_pki_cert))
+
+- type: replace
+  path: /instance_groups/name=vault/jobs/name=vault/properties/safe/tls/key?
+  value: ((vault_pki_key))
+
+- type: replace
+  path: /instance_groups/name=vault/jobs/name=vault/properties/safe/ui?
+  value: true
+
+- type: replace
+  path: /instance_groups/name=vault/networks/0/static_ips?
+  value: [((vault_ip))]


### PR DESCRIPTION
- Adding support for TLS/PKI certs on the vault server via patching.  
  Note: `vault_pki_cert` and `vault_pki_key` must be added to vault-params.yml.
- Set paths to variables based on script path execution.
- Moved argument logic to beginning of script.
- Set bosh stemcell info to variables.
- Added logic to skip stemcell download if already exists